### PR TITLE
Use babel by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint ./**/*.js",
     "precommit": "lint-staged",
-    "test": "./node_modules/.bin/mocha --require babel-core/register",
+    "test": "./node_modules/.bin/mocha",
     "test-debug": "./node_modules/.bin/mocha --debug-brk"
   },
   "author": "IT Shark Pro",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --colors
+--require babel-core/register


### PR DESCRIPTION
### Problem
To debug tests via VS Code or Node inspector we need to use babel

* set babel as mocha dependency

Debug with zero configurations:
VS Code `launch.json`:
```
"configurations": [
        {
          "type": "node",
          "request": "launch",
          "name": "Tests",
          "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
          "args": [],
          "internalConsoleOptions": "openOnSessionStart"
        }
    ]
```